### PR TITLE
md formatting and fixed missing newline for when no ciphers are found

### DIFF
--- a/lsciphers.go
+++ b/lsciphers.go
@@ -34,12 +34,12 @@ func main() {
         ciphers := list(target, bar)
         bar.End()
         bar.Erase()
-        fmt.Printf("%s:\n", target)
+        fmt.Printf("- %s\n", target)
         for _, cipher := range ciphers {
-            fmt.Printf("  %s\n", cipher)
+            fmt.Printf("  - %s\n", cipher)
         }
         if len(ciphers) == 0 {
-            fmt.Println("No ciphers matched.")
+            fmt.Println("  - No ciphers matched.\n")
         }
     }
 }


### PR DESCRIPTION
Added a dash before printing out results to make easy copy + paste to markdown, also added a missing newline after "no ciphers match" error and indented the error so it will appear related to the host.
